### PR TITLE
rust-nightly: correct version

### DIFF
--- a/pkgs/rust-nightly/default.nix
+++ b/pkgs/rust-nightly/default.nix
@@ -3,7 +3,7 @@
 let
   # Note: the version MUST be one version prior to the version we're
   # building
-  version = "2018-12-21";
+  version = "2018-12-20";
 
   # fetch hashes by running `print-hashes.sh nightly 2018-09-05`
   hashes = {


### PR DESCRIPTION
The bumped hashes are for a day earlier than specified, so building failed.