### PR TITLE
snowboy: my silly approach to init at v1.3.0

### DIFF
--- a/pkgs/rhasspy/default.nix
+++ b/pkgs/rhasspy/default.nix
@@ -60,7 +60,7 @@
   };
 
   rhasspy-wake-snowboy-hermes = callPackage ./rhasspy-wake-snowboy-hermes {
-    inherit rhasspy-hermes;
+    inherit rhasspy-hermes snowboy;
   };
 
   rhasspy-dialogue-hermes = callPackage ./rhasspy-dialogue-hermes  {
@@ -132,6 +132,8 @@
       rhasspy-server-hermes
     ;
   };
+
+  snowboy = callPackage ./snowboy {};
 
   swagger-ui-py = callPackage ./swagger-ui-py {};
 

--- a/pkgs/rhasspy/rhasspy-wake-snowboy-hermes/default.nix
+++ b/pkgs/rhasspy/rhasspy-wake-snowboy-hermes/default.nix
@@ -1,5 +1,5 @@
 { stdenv, buildPythonPackage, fetchFromGitHub
-, paho-mqtt, rhasspy-hermes }:
+, paho-mqtt, rhasspy-hermes, snowboy }:
 
 buildPythonPackage rec {
   pname = "rhasspy-wake-snowboy-hermes";
@@ -13,7 +13,7 @@ buildPythonPackage rec {
   };
 
   propagatedBuildInputs = [
-    rhasspy-hermes
+    rhasspy-hermes snowboy
   ];
 
   meta = with stdenv.lib; {

--- a/pkgs/rhasspy/snowboy/0001-use-openblas-instead-of-atlas.patch
+++ b/pkgs/rhasspy/snowboy/0001-use-openblas-instead-of-atlas.patch
@@ -1,0 +1,17 @@
+diff --git a/swig/Python3/Makefile b/swig/Python3/Makefile
+index 5bf8b15..db8fbb4 100644
+--- a/swig/Python3/Makefile
++++ b/swig/Python3/Makefile
+@@ -43,11 +43,7 @@ else
+   CXXFLAGS += -std=c++0x
+   # Make sure you have Atlas installed. You can statically link Atlas if you
+   # would like to be able to move the library to a machine without Atlas.
+-  ifneq ("$(ldconfig -p | grep lapack_atlas)","")
+-    LDLIBS := -lm -ldl -lf77blas -lcblas -llapack_atlas -latlas
+-  else
+-    LDLIBS := -lm -ldl -lf77blas -lcblas -llapack -latlas
+-  endif
++  LDLIBS := -lm -ldl -llapack -lopenblas
+   SNOWBOYDETECTLIBFILE = $(TOPDIR)/lib/ubuntu64/libsnowboy-detect.a
+   ifneq (,$(findstring arm,$(shell uname -m)))
+     SNOWBOYDETECTLIBFILE = $(TOPDIR)/lib/rpi/libsnowboy-detect.a

--- a/pkgs/rhasspy/snowboy/default.nix
+++ b/pkgs/rhasspy/snowboy/default.nix
@@ -1,0 +1,51 @@
+{ lib
+, buildPythonPackage
+, fetchFromGitHub
+, swig
+, pkgconfig
+, ncurses
+, openblas
+, blas
+, lapack
+, pyaudio
+}:
+
+assert blas.implementation == "openblas" && lapack.implementation == "openblas";
+
+buildPythonPackage rec {
+  pname = "snowboy";
+  version = "v1.3.0";
+
+  src = fetchFromGitHub {
+    owner = "Kitt-AI";
+    repo = pname;
+    rev = version;
+    sha256 = "186r8ihbhw76878244g3m56zwc4wcrdiriamvjp6s1hi6i35364s";
+  };
+
+  patches = [
+    ./0001-use-openblas-instead-of-atlas.patch
+  ];
+
+  nativeBuildInputs = [
+    swig
+    pkgconfig
+  ];
+
+  buildInputs = [
+    ncurses
+    lapack
+    blas
+    openblas
+  ];
+
+  propagatedBuildInputs = [
+    pyaudio
+  ];
+
+  meta = with lib; {
+    description = "DNN based hotword and wake word detection toolkit";
+    homepage = "https://github.com/Kitt-AI/snowboy";
+    license = licenses.asl20;
+  };
+}


### PR DESCRIPTION
Ich habe wenig bis keine Ahnung was ich bei den LDLIBS patchen tue. Keine Ahnung ob das so funktionieren kann.

Wenn ich es auf der Konsole ausprobiere coredumpt es :cry:.

```
❯ ./bin/rhasspy-wake-snowboy-hermes --model jarvis.umdl --model-dir lib/python3.7/site-packages/rhasspywake_snowboy_hermes/models
ERROR (ClassifySensitivities():pipeline-detect.cc:744) PipelineDetect: number of hotwords and number of sensitivities mismatch, expecting sensitivities for 0 personal hotwords, and 2 universal hotwords, got 1 sensitivities instead.
terminate called after throwing an instance of 'std::runtime_error'
  what():  ERROR (ClassifySensitivities():pipeline-detect.cc:744) PipelineDetect: number of hotwords and number of sensitivities mismatch, expecting sensitivities for 0 personal hotwords, and 2 universal hotwords, got 1 sensitivities instead.

[stack trace: ]
/nix/store/gqvahnphxs7k8qd6jivwmxhrxjg8gm5f-python3.7-snowboy-v1.3.0/lib/python3.7/site-packages/snowboy/_snowboydetect.so(_ZN7snowboy13GetStackTraceEv+0x35) [0x7f3d54c61285]
/nix/store/gqvahnphxs7k8qd6jivwmxhrxjg8gm5f-python3.7-snowboy-v1.3.0/lib/python3.7/site-packages/snowboy/_snowboydetect.so(_ZN7snowboy13SnowboyLogMsgD1Ev+0x47a) [0x7f3d54c6186a]
/nix/store/gqvahnphxs7k8qd6jivwmxhrxjg8gm5f-python3.7-snowboy-v1.3.0/lib/python3.7/site-packages/snowboy/_snowboydetect.so(_ZNK7snowboy14PipelineDetect21ClassifySensitivitiesERKSsPSsS3_+0x22e) [0x7f3d54c4d48e]
/nix/store/gqvahnphxs7k8qd6jivwmxhrxjg8gm5f-python3.7-snowboy-v1.3.0/lib/python3.7/site-packages/snowboy/_snowboydetect.so(_ZN7snowboy14PipelineDetect14SetSensitivityERKSs+0x14a) [0x7f3d54c4dbaa]
/nix/store/gqvahnphxs7k8qd6jivwmxhrxjg8gm5f-python3.7-snowboy-v1.3.0/lib/python3.7/site-packages/snowboy/_snowboydetect.so(+0x2631a) [0x7f3d54c3e31a]
.
.
.
/nix/store/syqcp8zb9c0vxj2sx6jbv5f9q7yki4jz-python3-3.7.7/lib/libpython3.7m.so.1.0(PyRun_SimpleFileExFlags+0xfb) [0x7f3d6415e6cb]
/nix/store/syqcp8zb9c0vxj2sx6jbv5f9q7yki4jz-python3-3.7.7/lib/libpython3.7m.so.1.0(+0x1bcf2a) [0x7f3d6417ef2a]
/nix/store/syqcp8zb9c0vxj2sx6jbv5f9q7yki4jz-python3-3.7.7/lib/libpython3.7m.so.1.0(_Py_UnixMain+0x49) [0x7f3d6417f1a9]
/nix/store/bwzra330vib0ik4d3l8rq6gp6y2ah1fr-glibc-2.30/lib/libc.so.6(__libc_start_main+0xeb) [0x7f3d63bf1d8b]
/nix/store/syqcp8zb9c0vxj2sx6jbv5f9q7yki4jz-python3-3.7.7/bin/python3.7(_start+0x2a) [0x40107a]

[1]    28611 abort (core dumped)  ./bin/rhasspy-wake-snowboy-hermes --model jarvis.umdl
```