### PR TITLE
rhasspyPackages.rhasspy-profile: relax aiohttp dependency

### DIFF
--- a/pkgs/rhasspy/rhasspy-profile/default.nix
+++ b/pkgs/rhasspy/rhasspy-profile/default.nix
@@ -25,6 +25,7 @@ buildPythonPackage rec {
 
   postPatch = ''
     patchShebangs ./configure
+    sed -i "s/aiohttp==.*/aiohttp/" requirements.txt
     sed -i "s/aiofiles==.*/aiofiles/" requirements.txt
     sed -i "s/json5==.*/json5/" requirements.txt
   '';


### PR DESCRIPTION
Pins 3.6.2, but we have 3.6.3, so relax it.