### PR TITLE
Fix missing /dev/stderr for cat2()

### DIFF
--- a/pkgs/irc-announce/default.nix
+++ b/pkgs/irc-announce/default.nix
@@ -32,7 +32,12 @@
   # echo2 and cat2 are used output to both, stdout and stderr
   # This is used to see what we send to the irc server. (debug output)
   echo2() { echo "$*"; echo "$*" >&2; }
-  cat2() { tee /dev/stderr; }
+  cat2() {
+    awk '{
+      print $0
+      print $0 > "/dev/stderr"
+    }'
+  }
 
   # privmsg_cat transforms stdin to a privmsg
   privmsg_cat() { awk '{ print "PRIVMSG "ENVIRON["IRC_CHANNEL"]" :"$0 }'; }


### PR DESCRIPTION
Credits to: https://cgit.krebsco.de/stockholm/tree/krebs/5pkgs/simple/irc-announce/default.nix?id=1e915baafbc56c4c626a3c3d042ac0e7d6276561